### PR TITLE
Added the ability to set any file extension

### DIFF
--- a/android/src/main/java/com/epicshaggy/filepicker/FilePicker.java
+++ b/android/src/main/java/com/epicshaggy/filepicker/FilePicker.java
@@ -44,6 +44,7 @@ public class FilePicker extends Plugin {
                         typeList.add("image/*");
                         break;
                     default:
+                        typeList.add(val);
                         break;
                 }
             } catch (JSONException e) {

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -135,7 +135,7 @@ public class FilePicker: CAPPlugin {
                 acceptTypes.append(kUTTypeImage)
                 break
             default:
-                acceptTypes.append(string as NSString)
+                acceptTypes.append(fileType as NSString)
                 break
             }
         }
@@ -148,8 +148,8 @@ public class FilePicker: CAPPlugin {
     }
     
     func getMimeTypeFrom(_ ext: String) -> String {
-        if ext != nil && mimeTypes.contains({ $0.0 == ext!.lowercaseString }) {
-            return mimeTypes[ext!.lowercaseString]!
+        if mimeTypes.keys.contains(ext.lowercased()) {
+            return mimeTypes[ext.lowercased()]!
         }
         return DEFAULT_MIME_TYPE
     }


### PR DESCRIPTION
The old way still works, this just let you add more mime types without the plugin restricting you. If you still want to use pdf/images to your project, just use the mime types for pdf/images

Thanks!